### PR TITLE
Fix import from non EcmaScript module

### DIFF
--- a/packages/otion/package.json
+++ b/packages/otion/package.json
@@ -18,18 +18,18 @@
 	"sideEffects": false,
 	"exports": {
 		".": {
-			"import": "./dist-node/esm/bundle.min.mjs",
-			"require": "./dist-node/cjs/bundle.min.js"
+			"import": "./dist-node/esm/bundle.min.js",
+			"require": "./dist-node/cjs/bundle.min.cjs"
 		},
 		"./runtime-deno": "./dist-deno/bundle.prod.min.mjs",
 		"./runtime-deno-dev": "./dist-deno/bundle.dev.mjs",
 		"./server": {
-			"import": "./server/index.mjs",
-			"require": "./server/index.js"
+			"import": "./server/index.js",
+			"require": "./server/index.cjs"
 		}
 	},
-	"main": "./dist-node/cjs/bundle.min.js",
-	"module": "./dist-node/esm/bundle.min.mjs",
+	"main": "./dist-node/cjs/bundle.min.cjs",
+	"module": "./dist-node/esm/bundle.min.js",
 	"types": "./dist-node/esm/bundle.d.ts",
 	"files": [
 		"dist-*/",

--- a/packages/otion/package.json
+++ b/packages/otion/package.json
@@ -16,6 +16,7 @@
 	"license": "MIT",
 	"author": "Kristóf Poduszló <kripod@protonmail.com>",
 	"sideEffects": false,
+	"type": "module",
 	"exports": {
 		".": {
 			"import": "./dist-node/esm/bundle.min.js",

--- a/rollup.config.base.js
+++ b/rollup.config.base.js
@@ -8,7 +8,7 @@ function getOutputs(pkg, subpath) {
 	return [
 		{
 			file: pkg.exports[subpath].import,
-			format: "esm",
+			format: "es",
 		},
 		{
 			file: pkg.exports[subpath].require,

--- a/rollup.config.base.js
+++ b/rollup.config.base.js
@@ -8,7 +8,7 @@ function getOutputs(pkg, subpath) {
 	return [
 		{
 			file: pkg.exports[subpath].import,
-			format: "es",
+			format: "esm",
 		},
 		{
 			file: pkg.exports[subpath].require,


### PR DESCRIPTION
The change of extensions was tested manually in the clean installation of gatsby.

Whats change: 
- import use **.js** extension
- require use **.cjs** extensions as described in [output plugins](https://rollupjs.org/guide/en/#outputplugins)