### PR TITLE
ScopedCSSRules[] on css function

### DIFF
--- a/packages/otion/src/createInstance.ts
+++ b/packages/otion/src/createInstance.ts
@@ -65,7 +65,7 @@ export interface OtionInstance {
 	 *   }
 	 * });
 	 */
-	css(rules: ScopedCSSRules): string;
+	css(rules: ScopedCSSRules | ScopedCSSRules[]): string;
 
 	// used to specify the values for the animating properties at various points during the animation
 	/**
@@ -297,10 +297,17 @@ export function createInstance(): OtionInstance {
 		},
 
 		css(rules): string {
-			if (isDev) checkSetup();
+			let styles: ScopedCSSRules = {};
+			if ((rules as any).length) {
+				(rules as ScopedCSSRules[]).forEach((rule: ScopedCSSRules) => {
+					styles = Object.assign(styles, rule);
+				});
+			} else {
+				styles = rules as ScopedCSSRules;
+			}
 
 			// The leading white space character gets removed
-			return decomposeToClassNames(rules, "", "").slice(1);
+			return decomposeToClassNames(styles, "", "").slice(1);
 		},
 
 		keyframes(rules): { toString(): string } {

--- a/packages/otion/src/index.ts
+++ b/packages/otion/src/index.ts
@@ -1,5 +1,7 @@
 import { createInstance, OtionInstance } from "./createInstance";
 
+export type { ScopedCSSRules } from "./cssTypes";
+
 export { createInstance };
 
 const defaultInstance = createInstance();


### PR DESCRIPTION
As mentioned in issue #28:

- This change will allow accept ScopedCSSRules and ScopedCSSRules[] on `css` function. E.g.:

```ts
css({ margin: 0 })

// or

const btnBase: ScopedCSSRules  = ({ margin: 0, padding: 10, color: '#0088cc' })
css([btnBase, { padding: 0 }])

// { margin: 0, padding: 0, color: '#0088cc' }
```

- This change also avoids the use of `!import`, since there will not be 2 styles with the same property.

- And last but not least, this change does not break the current use of the `css` function