### PR TITLE
Use map().join instead forEach and slice

### DIFF
--- a/packages/otion/src/createInstance.ts
+++ b/packages/otion/src/createInstance.ts
@@ -141,13 +141,11 @@ export function createInstance(): OtionInstance {
 			return normalizeDeclaration(property, value);
 		}
 
-		let cssText = "";
-		value.forEach((fallbackValue) => {
-			cssText += `;${normalizeDeclaration(property, fallbackValue)}`;
-		});
-
-		// The leading declaration separator character gets removed
-		return cssText.slice(1);
+		return value
+			.map((fallbackValue: string | number) =>
+				normalizeDeclaration(property, fallbackValue),
+			)
+			.join(";");
 	}
 
 	function decomposeToClassNames(


### PR DESCRIPTION
This is a small change and has no breaks in the execution of the process.

The main motivation is to eliminate the additional step (.slice) and increase performance by generating an array of strings and merging with the separator ';' between them instead of concatenating strings.

This change also reduces the packet size by 43 bytes