### PR TITLE
[Draft]: Composable classnames #47

### DIFF
--- a/packages/example-gatsby/src/pages/rfc.tsx
+++ b/packages/example-gatsby/src/pages/rfc.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable simple-import-sort/sort */
+import {
+	css as orgCSS,
+	stylesCompose,
+	stylesCreate,
+	stylesClassnames,
+} from "otion";
+import * as React from "react";
+
+/**
+ * `css` would have this API
+ */
+interface ExtendedCSS {
+	create: typeof stylesCreate;
+	compose: typeof stylesCompose;
+	cls: typeof stylesClassnames;
+}
+const css: typeof orgCSS & ExtendedCSS = Object.assign(orgCSS, {
+	create: stylesCreate,
+	compose: stylesCompose,
+	cls: stylesClassnames,
+});
+
+const styles = css.create({
+	blue: { color: "blue", border: "1px solid" },
+	green: { color: "green" },
+	hotpink: { color: "hotpink", selectors: { "&:hover": { color: "pink" } } },
+});
+const combined = stylesCompose(styles.blue, styles.green, styles.hotpink);
+const className = stylesClassnames(styles.blue, styles.hotpink);
+
+export default function IndexPage(): JSX.Element {
+	return (
+		<React.StrictMode>
+			<h1 className={css({ color: "hotpink" })}>Hello, world!</h1>
+			<h2>Style Object (styles):</h2>
+			<pre>
+				<code>{JSON.stringify(styles, null, 2)}</code>
+			</pre>
+			<h2>
+				Combine style objects (styles.blue, styles.green, styles.hotpink):
+			</h2>
+			<pre>
+				<code>{JSON.stringify(combined, null, 2)}</code>
+			</pre>
+			<h2>
+				Single className from style objects (styles.blue, styles.hotpink):
+			</h2>
+			<pre>
+				<code>{JSON.stringify(className, null, 2)}</code>
+			</pre>
+		</React.StrictMode>
+	);
+}

--- a/packages/example-gatsby/src/pages/rfc.tsx
+++ b/packages/example-gatsby/src/pages/rfc.tsx
@@ -26,8 +26,8 @@ const styles = css.create({
 	green: { color: "green" },
 	hotpink: { color: "hotpink", selectors: { "&:hover": { color: "pink" } } },
 });
-const combined = stylesCompose(styles.blue, styles.green, styles.hotpink);
-const className = stylesClassnames(styles.blue, styles.hotpink);
+const combined = css.compose(styles.blue, styles.green, styles.hotpink);
+const className = css.cls(styles.blue, styles.hotpink);
 
 export default function IndexPage(): JSX.Element {
 	return (

--- a/packages/otion/src/cssTypes.ts
+++ b/packages/otion/src/cssTypes.ts
@@ -10,6 +10,9 @@ export type CSSRules<
 > = CSSStyleRules<P> & CSSGroupingRules<P>;
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ScopedCSSRules extends CSSRules<ScopedCSSProperties> {}
+export interface GroupScopedCSSRules {
+	[styleName: string]: ScopedCSSRules;
+}
 
 export type CSSStyleRules<P extends Record<string, any> = CSSProperties> = P &
 	{ [pseudo in CSS.SimplePseudos]?: P } & {
@@ -30,3 +33,14 @@ export interface CSSGroupingRules<
 export type CSSKeyframeRules =
 	| { [time in "from" | "to"]?: CSSProperties }
 	| { [time: string]: CSSProperties };
+
+/**
+ * Transform Union types to Intersection:
+ * From: { a: string } | { b: string }
+ * To: { a: string } & { b: string }
+ */
+export type UnionToIntersection<U> = (
+	U extends any ? (k: U) => void : never
+) extends (k: infer I) => void
+	? I
+	: never;

--- a/packages/otion/src/index.ts
+++ b/packages/otion/src/index.ts
@@ -1,5 +1,8 @@
 import { createInstance, OtionInstance } from "./createInstance";
 
+export { stylesCompose } from "./utils/stylesCompose";
+export { stylesCreate } from "./utils/stylesCreate";
+export { stylesClassnames } from "./utils/stylesClassnames";
 export { createInstance };
 
 const defaultInstance = createInstance();
@@ -15,4 +18,4 @@ export const keyframes: OtionInstance["keyframes"] = defaultInstance.keyframes;
 
 export { CSSOMInjector, DOMInjector, NoOpInjector } from "./injectors";
 
-export type { ScopedCSSRules } from "./cssTypes";
+export type { ScopedCSSRules, GroupScopedCSSRules } from "./cssTypes";

--- a/packages/otion/src/utils/stylesClassnames.ts
+++ b/packages/otion/src/utils/stylesClassnames.ts
@@ -1,0 +1,58 @@
+/* eslint-disable prefer-spread */
+/* eslint-disable no-multi-assign */
+/* eslint-disable simple-import-sort/sort */
+/* eslint-disable prefer-destructuring */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-continue */
+import { stylesCompose } from "./stylesCompose";
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * Compose class names from one or more style objects
+ *
+ * @todo
+ * - Better description
+ *
+ * @example
+ * ```javascript
+ * const styles = css.create({
+ *  blue: { color: "red", border: "1px solid" },
+ *  hotpink: { color: "hotpink" },
+ * );
+ * const className = css.cls(styles.blue, styles.hotpink);
+ * // output: "3sn2xs 147pvhj"
+ * // result is: color hotpink & border 1px solid
+ * ```
+ */
+export function stylesClassnames<T extends { [styleName: string]: unknown }[]>(
+	...styleObjects: T
+): string {
+	/**
+	 * Combine and dedupe style objects
+	 */
+	const styleObject = stylesCompose(...styleObjects);
+	let classNames = "";
+
+	for (const propName in styleObject) {
+		// Ignore inherited props
+		if (!hasOwnProperty.call(styleObject, propName)) continue;
+
+		// Explicitly type as `Record | string` because value is `UnionToIntersection<T[number]>`
+		const propValue = (styleObject[propName] as unknown) as
+			| Record<string, unknown>
+			| string;
+
+		if (propValue != null) {
+			if (typeof propValue === "string") {
+				classNames += classNames ? ` ${propValue}` : propValue;
+			} else if (typeof propValue === "object") {
+				classNames += classNames
+					? ` ${stylesClassnames(propValue)}`
+					: stylesClassnames(propValue);
+			}
+		}
+	}
+
+	return classNames;
+}

--- a/packages/otion/src/utils/stylesCompose.ts
+++ b/packages/otion/src/utils/stylesCompose.ts
@@ -1,0 +1,82 @@
+/* eslint-disable prefer-object-spread */
+/* eslint-disable prefer-destructuring */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-continue */
+import type { UnionToIntersection } from "../cssTypes";
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * @description
+ * Composes two or more style objects into a single style object,
+ * de-duplicating styles. Last argument overrides, first or previous arguments
+ *
+ * @todo
+ * - Better description
+ * - Maybe typings could be better 🤷‍♀️
+ *
+ * @example
+ * ```javascript
+ * const styles = css.create({
+ *  blue: { color: "red", border: "1px solid" },
+ *  green: { color: "green" },
+ *  hotpink: { color: "hotpink" },
+ * );
+ * const composedStyles = css.compose(styles.blue, styles.green, styles.hotpink)
+ * // Output
+ * // {
+ * //   color: '3sn2xs', // << 'hotpink',
+ * //   border: '147pvhj',
+ * // }
+ */
+export function stylesCompose<T extends { [styleName: string]: unknown }[]>(
+	...styleObjects: T
+): UnionToIntersection<T[number]> {
+	if (styleObjects.length === 0) return {} as UnionToIntersection<T[number]>;
+	if (styleObjects.length === 1)
+		return styleObjects[0] as UnionToIntersection<T[number]>;
+
+	/**
+	 * Reverse because ..
+	 * - `pop` from end of array is faster than `shift` from top (at least in V8)
+	 * - Last in reversed array (`pop`ed) should be assigned first, so next can override
+	 */
+	styleObjects.reverse();
+
+	const stylesComposed = {} as Record<string, unknown>;
+
+	while (styleObjects.length) {
+		const styleCurrent = styleObjects.pop();
+
+		if (styleCurrent != null && typeof styleCurrent === "object") {
+			for (const propName in styleCurrent) {
+				// Ignore inherited props
+				if (!hasOwnProperty.call(styleCurrent, propName)) continue;
+
+				const propValue = styleCurrent[propName];
+
+				if (typeof propValue === "string") {
+					stylesComposed[propName] = propValue;
+				} else if (propValue != null && typeof propValue === "object") {
+					let propValueObject = stylesComposed[propName];
+
+					/**
+					 * For safety, prevent assigning to string | number | null | undefined
+					 * - if null | undefined -> it's first time this property appears
+					 * - if string | number | any -> e.g: [{ selectors: '' }, { selectors: {...} }] (should error instead of falling to {} ?)
+					 */
+					if (propValueObject == null || typeof propValueObject !== "object") {
+						propValueObject = {} as typeof propValueObject;
+					}
+
+					stylesComposed[propName] = stylesCompose(
+						propValueObject as Record<string, unknown>,
+						(styleCurrent[propName] as unknown) as Record<string, unknown>,
+					);
+				}
+			}
+		}
+	}
+
+	return stylesComposed as UnionToIntersection<T[number]>;
+}

--- a/packages/otion/src/utils/stylesCreate.ts
+++ b/packages/otion/src/utils/stylesCreate.ts
@@ -1,0 +1,65 @@
+/* eslint-disable no-multi-assign */
+/* eslint-disable simple-import-sort/sort */
+/* eslint-disable prefer-destructuring */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-continue */
+import hash from "@emotion/hash";
+import type { GroupScopedCSSRules } from "../cssTypes";
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * Create style objects
+ *
+ * @todo
+ * - Better description
+ * - Maybe typings could be better 🤷‍♀️
+ *
+ * @example
+ * ```javascript
+ * const styles = css.create({
+ *  box: { border: '1px solid blue' },
+ *  foo: { color: 'hotpink' },
+ * })
+ * // output
+ * // {
+ * //   box: { border: '1bckp73' },
+ * //   foo: { color: '3sn2xs' },
+ * // }
+ * ```
+ */
+export function stylesCreate<T extends GroupScopedCSSRules>(styleObject: T): T {
+	const result: Record<string, unknown> = {};
+
+	for (const styleName in styleObject) {
+		// Ignore inherited props
+		if (!hasOwnProperty.call(styleObject, styleName)) continue;
+
+		const styleValue = styleObject[styleName];
+
+		if (styleValue == null || typeof styleValue !== "object") continue; // Raise error?
+
+		// This should be ⤵
+		// result[styleName] = css(styleValue) // > { [cssProp: string]: className }
+
+		// From here on is just a mock for `css` call that displays expected output
+		// { [cssProp: string]: className }
+
+		const currentResult = (result[styleName] = {} as Record<string, unknown>);
+
+		for (const cssProp in styleValue) {
+			if (!hasOwnProperty.call(styleValue, cssProp)) continue;
+			const cssValue = styleValue[cssProp];
+
+			if (typeof cssValue === "string") {
+				currentResult[cssProp] = hash(`${cssProp}:${cssValue}`);
+			} else if (typeof cssValue != null && typeof cssValue === "object") {
+				currentResult[cssProp] = stylesCreate(
+					(cssValue as unknown) as GroupScopedCSSRules, // Selectors, media
+				);
+			}
+		}
+	}
+
+	return result as T;
+}


### PR DESCRIPTION
## Description (see: #47)

This PR is a draft (and PoC) of a new API for otion inspired by React `stylex`. The implementation is a bit different from what was mentioned in #47 
- No `toString()` added
- No breaking changes

## Details

It add 3 methods:
- `stylesCreate` – Allows to create style objects. This is basically just an object with string keys that can contain CSS properties (as in `css(...)`). This is partially implemented and it only runs `hash(value)` instead of calling `css(...)`
```javascript
const styles = css.create({
	blue: { color: "blue", border: "1px solid" },
	green: { color: "green" },
	hotpink: { color: "hotpink", selectors: { "&:hover": { color: "pink" } } },
});
styles.blue // { color: [classname], border: [classname] }
styles.blue.color // [classname]
```

- `stylesCompose` – Allows to compose two or more style objects into a single one. Right side argument overrides left side argument styles
```javascript
const styles = css.create({
	blue: { color: "blue", border: "1px solid" },
	green: { color: "green" },
	hotpink: { color: "hotpink", selectors: { "&:hover": { color: "pink" } } },
});
const combined = css.compose(styles.blue, styles.green, styles.hotpink);
combined.color // [classname] for "hotpink" (right-side overrides left side)
combined.border // [classname] for "1px solid"
combined.selectors["&:hover"].color // [classname] for "pink"
```

- `stylesClassnames` – Calls `stylesCompose` if more than one style object is passed & combines all classnames into a single string (as what `css(...)` does but for style objects)
```javascript
const styles = css.create({
	blue: { color: "blue", border: "1px solid" },
	hotpink: { color: "hotpink", selectors: { "&:hover": { color: "pink" } } },
});
const className = css.cls(styles.blue, styles.hotpink) // "3sn2xs 147pvhj 1666u7v"
```

A new page was added to `gatsby` example, called `rfc.tsx`. Visit locally `http://localhost:8000/rfc` to see how it behaves.

The `gatsby` page creates a mock or would-be API that would be backwards compatible with what `css` is now:
```javascript
css(...) // As it is now
css.create(...)
css.compose(...)
css.cls(...)
```

Soo .. thoughts? 😅 
There are some bothering eslint rules that I ignored that are up for discussion too 😆 